### PR TITLE
이슈템플릿 이슈타입 드롭다운으로 수정

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/issue-form.yml
@@ -4,19 +4,21 @@ labels: [order]
 title: "이슈 이름을 작성해주세요"
 
 body:
-  - type: checkboxes
+  - type: dropdown
     id: issueType
     attributes:
       label: "이슈 유형 (Issue Type)"
       description: "해당하는 이슈 유형을 선택해주세요."
       options:
-        - label: "🛠️ Refactor"
-        - label: "✅ Update"
-        - label: "🐞 Bug"
-        - label: "🎨 Style"
-        - label: "✨ Feature"
-        - label: "🗑️ Delete"
-        - label: "🛠️ Fix"
+        - "🛠️ Refactor: 기존 코드를 개선하지만 기능은 변경되지 않습니다."
+        - "✅ Update: 기존 기능을 수정하거나 개선합니다."
+        - "🐞 Bug: 오류나 문제를 수정합니다."
+        - "🎨 Style: 코드 스타일이나 UI를 개선합니다 (기능 변경 없음)."
+        - "✨ Feature: 새로운 기능을 추가합니다."
+        - "🗑️ Delete: 불필요한 기능이나 코드를 제거합니다."
+        - "🛠️ Fix: 사소한 문제나 오류를 수정합니다."
+    validations:
+      required: true
 
   - type: input
     id: parentKey


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## ✨ 내용

이슈에서 이슈타입을 중복으로 선택하는거보다 드롭다운으로 한가지만 선택할 수 있도록 변경했습니다.
각 이슈마다 설명을 추가해서 어떤상황에서 사용해야하는지 적어뒀습니다.

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요하면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
